### PR TITLE
Use HTTPS version of the API

### DIFF
--- a/dota2api/src/urls.py
+++ b/dota2api/src/urls.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """The base URL and the API calls are defined in this file"""
 
-BASE_URL = "http://api.steampowered.com/"
+BASE_URL = "https://api.steampowered.com/"
 GET_MATCH_HISTORY = "IDOTA2Match_570/GetMatchHistory/v001/"
 GET_MATCH_HISTORY_BY_SEQ_NUM = "IDOTA2Match_570/GetMatchHistoryBySequenceNum/v0001/"
 GET_MATCH_DETAILS = "IDOTA2Match_570/GetMatchDetails/v001/"


### PR DESCRIPTION
It's a one character change but I see no reason not to use this over regular old HTTP connections.

Edit: wow, I can't type complete sentences...