### PR TITLE
Fix broken tests

### DIFF
--- a/tests/src/reponse_test.py
+++ b/tests/src/reponse_test.py
@@ -7,6 +7,8 @@ from dota2api.src.exceptions import *
 from dota2api.src.urls import *
 from tests.utils import *
 
+PLAYER_ID=3420585
+
 
 class TestBuildDota2Dict(unittest.TestCase):
     def setUp(self):
@@ -34,7 +36,7 @@ class TestBuildDota2Dict(unittest.TestCase):
         self.assertEqual(len(dota2dict['matches']), 1)
 
     def test_get_match_history_from_only_one_player(self):
-        url = BASE_URL + GET_MATCH_HISTORY + request_pars(LANGUAGE_PAR, 'account_id=112351324', STEAM_ID_PAR,
+        url = BASE_URL + GET_MATCH_HISTORY + request_pars(LANGUAGE_PAR, 'account_id=%d' % PLAYER_ID, STEAM_ID_PAR,
                                                           'format=json', 'matches_requested=10')
         request = self.executor(url)
 
@@ -44,7 +46,7 @@ class TestBuildDota2Dict(unittest.TestCase):
 
         self.assertEqual(len(dota2dict['matches']), 10)
         for match in dota2dict['matches']:
-            player_is_in_match = bool([p for p in match['players'] if p['account_id'] == 112351324])
+            player_is_in_match = bool([p for p in match['players'] if p['account_id'] == PLAYER_ID])
             self.assertTrue(player_is_in_match, 'Player was not in a match from the result')
 
     def test_request_match_detail_on_a_non_existent_match(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,12 @@ import os
 
 DEFAULT_MATCHES_SIZE = 100
 LANGUAGE_PAR = 'language=en_us'
-STEAM_ID_PAR = 'key=' + os.environ.get('D2_API_KEY')
+
+if not os.environ.get('D2_API_KEY'):
+    exit("Please set D2_API_KEY environment variable.")
+else:
+    STEAM_ID_PAR = 'key=' + os.environ.get('D2_API_KEY')
+
 
 
 def convert_to_64_bit(number):


### PR DESCRIPTION
tests are broken because it assumes that d2_api_key is set and the PLAYER_ID you had hard-coded turned off match sharing